### PR TITLE
analysis: new canonical URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+notifications:
+  email: false
+
+sudo: true
+
+language: python
+
+cache:
+  - pip
+
+python:
+  - 2.7
+
+services:
+  - docker
+
+before_install:
+  - travis_retry pip install yadage
+
+install:
+  - docker build -t reanahub/reana-demo-root6-roofit .
+
+script:
+  - yadage-validate workflow.yml | grep -q 'workflow validates'
+  - docker run -v `pwd`:/code -i -t --rm reanahub/reana-demo-root6-roofit root -b -q 'gendata.C(20000,"data.root")'
+  - ls -l data.root
+  - docker run -v `pwd`:/code -i -t --rm reanahub/reana-demo-root6-roofit root -b -q 'fitdata.C("data.root","plot.png")'
+  - ls -l plot.png

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ it was slightly modified. One could run it locally as follows::
 
 This generates a final plot representing the result of our analysis:
 
-.. figure:: https://raw.githubusercontent.com/tiborsimko/reana-demo-root6-roofit/master/plot.png
+.. figure:: https://raw.githubusercontent.com/reanahub/reana-demo-root6-roofit/master/plot.png
    :alt: plot.png
    :align: center
 

--- a/reana.yaml
+++ b/reana.yaml
@@ -1,5 +1,5 @@
 workflow: yadage
 yadage_file: workflow.yml
-yadage_toplevel: github:tiborsimko/reana-demo-root6-roofit
+yadage_toplevel: github:reanahub/reana-demo-root6-roofit
 yadage_nparallel: 1
 yadage_preset_parameters: {"events": "20000"}


### PR DESCRIPTION
* Amends URLs of the container image and the documentation now that this
  analysis example lives under "reanahub" organisation.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>