### PR TITLE
cwl: stdout capture for workflow steps

### DIFF
--- a/workflow/cwl/fitdata.cwl
+++ b/workflow/cwl/fitdata.cwl
@@ -24,7 +24,11 @@ arguments:
     valueFrom: |
       root -b -q '$(inputs.fitdata.basename)("$(inputs.data.basename)","$(runtime.outdir)/$(inputs.outfile)")'
 
+stdout: fitdata.log
+
 outputs:
+  fitdata.log:
+    type: stdout
   result:
     type: File
     outputBinding:

--- a/workflow/cwl/gendata.cwl
+++ b/workflow/cwl/gendata.cwl
@@ -9,7 +9,6 @@ requirements:
     listing:
       - $(inputs.gendata_tool)
 
-
 inputs:
   gendata_tool: File
   events: int
@@ -24,7 +23,11 @@ arguments:
     valueFrom: |
       root -b -q '$(inputs.gendata_tool.basename)($(inputs.events),"$(runtime.outdir)/$(inputs.outfilename)")'
 
+stdout: gendata.log
+
 outputs:
+  gendata.log:
+    type: stdout
   data:
     type: File
     outputBinding:

--- a/workflow/cwl/workflow.cwl
+++ b/workflow/cwl/workflow.cwl
@@ -13,7 +13,14 @@ outputs:
     type: File
     outputSource:
       fitdata/result
-
+  gendata.log:
+    type: File
+    outputSource:
+      gendata/gendata.log
+  fitdata.log:
+    type: File
+    outputSource:
+      fitdata/fitdata.log
 
 steps:
   gendata:
@@ -21,10 +28,10 @@ steps:
     in:
       gendata_tool: gendata_tool
       events: events
-    out: [data]
+    out: [data, gendata.log]
   fitdata:
     run: fitdata.cwl
     in:
       fitdata: fitdata_tool
       data: gendata/data
-    out: [result]
+    out: [result, fitdata.log]


### PR DESCRIPTION
* Captures standard output of workflow steps into `gendata.log` and
  `fitdata.log` log files.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>