### PR TITLE
cwl: input files with full relative path

### DIFF
--- a/workflow/cwl/input.yml
+++ b/workflow/cwl/input.yml
@@ -1,7 +1,7 @@
 events: 20000
 fitdata_tool:
   class: File
-  path: fitdata.C
+  path: code/fitdata.C
 gendata_tool:
   class: File
-  path: gendata.C
+  path: code/gendata.C


### PR DESCRIPTION
* Since inputs/outputs/code directories are unified for all workflow
  engines (see reanahub/reana-workflow-engine-cwl#48) code content
  is no longer copied into the workflow workspace direcotory. Because
  of this and because `reana-client` uploads all files with relative
  path to the user's workflow workspace, full relative path should be
  provided (i.e. `inputs/data.csv`).

Connect reanahub/reana-workflow-engine-cwl#47