### PR TITLE
reana.yaml: removals of inputs/code/outputs

### DIFF
--- a/reana-cwl.yaml
+++ b/reana-cwl.yaml
@@ -1,14 +1,7 @@
 version: 0.2.0
-code:
-  files:
-   - code/gendata.C
-   - code/fitdata.C
 inputs:
   parameters:
     input: workflow/cwl/input.yml
-outputs:
-  files:
-   - outputs/plot.png
 environments:
   - type: docker
     image: reanahub/reana-env-root6

--- a/reana-yadage.yaml
+++ b/reana-yadage.yaml
@@ -1,16 +1,9 @@
 version: 0.2.0
-code:
-  files:
-   - code/gendata.C
-   - code/fitdata.C
 inputs:
   parameters:
     events: 20000
     gendata: code/gendata.C
     fitdata: code/fitdata.C
-outputs:
-  files:
-   - outputs/plot.png
 environments:
   - type: docker
     image: reanahub/reana-env-root6

--- a/reana.yaml
+++ b/reana.yaml
@@ -1,14 +1,8 @@
 version: 0.3.0
-code:
-  files:
-   - code/gendata.C
-   - code/fitdata.C
 inputs:
-  parameters:
-    events: 20000
-outputs:
   files:
-   - outputs/plot.png
+    - code/gendata.C
+    - code/fitdata.C
 environments:
   - type: docker
     image: reanahub/reana-env-root6


### PR DESCRIPTION
* Removes the sections from the reana.yaml files for the
  CWL, Yadage, Serial engines that can be removed without
  affecting the execution of the demo.

Connects https://github.com/reanahub/reana-client/issues/109

Signed-off-by: Dinos Kousidis <dinos.kousidis@cern.ch>