### PR TITLE
environment: pin ROOT 6.18.04 version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,10 +67,13 @@ encapsulated by using the upstream `reana-env-root6
 <https://github.com/reanahub/reana-env-root6>`_ base image. (See there how it
 was created.)
 
-We can actually use this container image "as is", because our two macros
-``gendata.C`` and ``fitdata.C`` can be "uploaded" or "mounted" into the runtime
-container. We therefore don't need to create any specially customised
-environment.
+We shall use the ROOT version 6.18.04. Note that we can actually use this
+container image "as is", because our two macros ``gendata.C`` and ``fitdata.C``
+can be "uploaded" and "mounted" into the running container at runtime. There is
+no need to compile any of the analysis source code beforehand. We can therefore
+use the ROOT 6.18.04 base image directly, without building a new container
+image specially dedicated to our analysis. The ROOT 6.18.04 base image fully
+specifies the complete analysis environment that we need for our analysis.
 
 4. Analysis workflow
 --------------------
@@ -147,7 +150,7 @@ workflow steps and expected outputs:
       type: serial
       specification:
         steps:
-          - environment: 'reanahub/reana-env-root6'
+          - environment: 'reanahub/reana-env-root6:6.18.04'
             commands:
             - mkdir -p results
             - root -b -q 'code/gendata.C(${events},"${data}")' | tee gendata.log

--- a/reana-htcondorcern.yaml
+++ b/reana-htcondorcern.yaml
@@ -12,13 +12,13 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'reanahub/reana-env-root6'
+        environment: 'reanahub/reana-env-root6:6.18.04'
         compute_backend: htcondorcern
         commands:
         - mkdir -p results
         - root -b -q 'code/gendata.C(${events},"${data}")' | tee gendata.log
       - name: fitdata
-        environment: 'reanahub/reana-env-root6'
+        environment: 'reanahub/reana-env-root6:6.18.04'
         compute_backend: htcondorcern
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")' | tee fitdata.log

--- a/reana-slurmcern.yaml
+++ b/reana-slurmcern.yaml
@@ -12,13 +12,13 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'reanahub/reana-env-root6'
+        environment: 'reanahub/reana-env-root6:6.18.04'
         compute_backend: slurmcern
         commands:
         - mkdir -p results
         - root -b -q 'code/gendata.C(${events},"${data}")' | tee gendata.log
       - name: fitdata
-        environment: 'reanahub/reana-env-root6'
+        environment: 'reanahub/reana-env-root6:6.18.04'
         compute_backend: slurmcern
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")' | tee fitdata.log

--- a/reana.yaml
+++ b/reana.yaml
@@ -12,12 +12,12 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'reanahub/reana-env-root6'
+        environment: 'reanahub/reana-env-root6:6.18.04'
         commands:
         - mkdir -p results
         - root -b -q 'code/gendata.C(${events},"${data}")' | tee gendata.log
       - name: fitdata
-        environment: 'reanahub/reana-env-root6'
+        environment: 'reanahub/reana-env-root6:6.18.04'
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")' | tee fitdata.log
 outputs:

--- a/workflow/cwl/fitdata.cwl
+++ b/workflow/cwl/fitdata.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 requirements:
   DockerRequirement:
     dockerPull:
-      reanahub/reana-env-root6
+      reanahub/reana-env-root6:6.18.04
   InitialWorkDirRequirement:
     listing:
       - $(inputs.fitdata)

--- a/workflow/cwl/gendata.cwl
+++ b/workflow/cwl/gendata.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 requirements:
   DockerRequirement:
     dockerPull:
-      reanahub/reana-env-root6
+      reanahub/reana-env-root6:6.18.04
   InitialWorkDirRequirement:
     listing:
       - $(inputs.gendata_tool)

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -32,6 +32,7 @@ stages:
         environment:
           environment_type: 'docker-encapsulated'
           image: 'reanahub/reana-env-root6'
+          imagetag: '6.18.04'
   - name: fitdata
     dependencies: [gendata]
     scheduler:
@@ -51,3 +52,4 @@ stages:
         environment:
           environment_type: 'docker-encapsulated'
           image: 'reanahub/reana-env-root6'
+          imagetag: '6.18.04'


### PR DESCRIPTION
* Pins ROOT version to 6.18.04 in order to better exemplify the
  principles behind long-term preservation of encapsulated analysis
  environments. (I.e. using 'latest' ROOT docker image would be calling
  for a moving target, while we want to freeze ROOT '6.18.04' version
  used in our original analysis, as it were.)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>