### PR TITLE
cwl: removes logs caputring

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,8 +153,8 @@ workflow steps and expected outputs:
           - environment: 'reanahub/reana-env-root6:6.18.04'
             commands:
             - mkdir -p results
-            - root -b -q 'code/gendata.C(${events},"${data}")' | tee gendata.log
-            - root -b -q 'code/fitdata.C("${data}","${plot}")' | tee fitdata.log
+            - root -b -q 'code/gendata.C(${events},"${data}")'
+            - root -b -q 'code/fitdata.C("${data}","${plot}")
     outputs:
       files:
         - results/plot.png

--- a/reana-htcondorcern.yaml
+++ b/reana-htcondorcern.yaml
@@ -16,12 +16,12 @@ workflow:
         compute_backend: htcondorcern
         commands:
         - mkdir -p results
-        - root -b -q 'code/gendata.C(${events},"${data}")' | tee gendata.log
+        - root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
         environment: 'reanahub/reana-env-root6:6.18.04'
         compute_backend: htcondorcern
         commands:
-        - root -b -q 'code/fitdata.C("${data}","${plot}")' | tee fitdata.log
+        - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:
   files:
     - results/plot.png

--- a/reana-slurmcern.yaml
+++ b/reana-slurmcern.yaml
@@ -16,12 +16,12 @@ workflow:
         compute_backend: slurmcern
         commands:
         - mkdir -p results
-        - root -b -q 'code/gendata.C(${events},"${data}")' | tee gendata.log
+        - root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
         environment: 'reanahub/reana-env-root6:6.18.04'
         compute_backend: slurmcern
         commands:
-        - root -b -q 'code/fitdata.C("${data}","${plot}")' | tee fitdata.log
+        - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:
   files:
     - results/plot.png

--- a/reana.yaml
+++ b/reana.yaml
@@ -15,11 +15,11 @@ workflow:
         environment: 'reanahub/reana-env-root6:6.18.04'
         commands:
         - mkdir -p results
-        - root -b -q 'code/gendata.C(${events},"${data}")' | tee gendata.log
+        - root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
         environment: 'reanahub/reana-env-root6:6.18.04'
         commands:
-        - root -b -q 'code/fitdata.C("${data}","${plot}")' | tee fitdata.log
+        - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:
   files:
     - results/plot.png

--- a/workflow/cwl/fitdata.cwl
+++ b/workflow/cwl/fitdata.cwl
@@ -24,11 +24,7 @@ arguments:
     valueFrom: |
       root -b -q '$(inputs.fitdata.basename)("$(inputs.data.basename)","$(runtime.outdir)/$(inputs.outfile)")'
 
-stdout: fitdata.log
-
 outputs:
-  fitdata.log:
-    type: stdout
   result:
     type: File
     outputBinding:

--- a/workflow/cwl/gendata.cwl
+++ b/workflow/cwl/gendata.cwl
@@ -23,11 +23,7 @@ arguments:
     valueFrom: |
       root -b -q '$(inputs.gendata_tool.basename)($(inputs.events),"$(runtime.outdir)/$(inputs.outfilename)")'
 
-stdout: gendata.log
-
 outputs:
-  gendata.log:
-    type: stdout
   data:
     type: File
     outputBinding:

--- a/workflow/cwl/workflow.cwl
+++ b/workflow/cwl/workflow.cwl
@@ -24,14 +24,6 @@ outputs:
     type: File
     outputSource:
       fitdata/result
-  gendata.log:
-    type: File
-    outputSource:
-      gendata/gendata.log
-  fitdata.log:
-    type: File
-    outputSource:
-      fitdata/fitdata.log
 
 steps:
   gendata:
@@ -39,10 +31,10 @@ steps:
     in:
       gendata_tool: gendata_tool
       events: events
-    out: [data, gendata.log]
+    out: [data]
   fitdata:
     run: fitdata.cwl
     in:
       fitdata: fitdata_tool
       data: gendata/data
-    out: [result, fitdata.log]
+    out: [result]


### PR DESCRIPTION
* Logs capturing is not needed anymore since it's done
  by job monitor.
  Closes reanahub/reana-workflow-engine-cwl/issues/132