### PR TITLE
yadage: HTCondor and Slurm examples

### DIFF
--- a/reana-yadage-htcondorcern.yaml
+++ b/reana-yadage-htcondorcern.yaml
@@ -1,0 +1,17 @@
+version: 0.6.0
+inputs:
+  files:
+    - code/gendata.C
+    - code/fitdata.C
+  directories:
+    - workflow/yadage
+  parameters:
+    events: 20000
+    gendata: code/gendata.C
+    fitdata: code/fitdata.C
+workflow:
+  type: yadage
+  file: workflow/yadage/workflow-htcondorcern.yaml
+outputs:
+  files:
+    - fitdata/plot.png

--- a/reana-yadage-slurmcern.yaml
+++ b/reana-yadage-slurmcern.yaml
@@ -1,0 +1,17 @@
+version: 0.6.0
+inputs:
+  files:
+    - code/gendata.C
+    - code/fitdata.C
+  directories:
+    - workflow/yadage
+  parameters:
+    events: 20000
+    gendata: code/gendata.C
+    fitdata: code/fitdata.C
+workflow:
+  type: yadage
+  file: workflow/yadage/workflow-slurmcern.yaml
+outputs:
+  files:
+    - fitdata/plot.png

--- a/workflow/yadage/workflow-htcondorcern.yaml
+++ b/workflow/yadage/workflow-htcondorcern.yaml
@@ -1,0 +1,59 @@
+# Note that if you are working on the analysis development locally, i.e. outside
+# of the REANA platform, you can proceed as follows:
+#
+#   $ cd reana-demo-root6-roofit
+#   $ mkdir -p yadage-local-run/yadage-inputs
+#   $ cd yadage-local-run
+#   $ cp -a ../code yadage-inputs
+#   $ yadage-run . ../workflow/yadage/workflow.yaml \
+#        -p events=20000 \
+#        -p gendata=code/gendata.C \
+#        -p fitdata=code/fitdata.C \
+#        -d initdir=`pwd`/yadage-inputs
+#   $ firefox fitdata/plot.png
+
+stages:
+  - name: gendata
+    dependencies: [init]
+    scheduler:
+      scheduler_type: 'singlestep-stage'
+      parameters:
+        events: {step: init, output: events}
+        gendata: {step: init, output: gendata}
+        outfilename: '{workdir}/data.root'
+      step:
+        process:
+          process_type: 'interpolated-script-cmd'
+          script: root -b -q '{gendata}({events},"{outfilename}")'
+        publisher:
+          publisher_type: 'frompar-pub'
+          outputmap:
+            data: outfilename
+        environment:
+          environment_type: 'docker-encapsulated'
+          image: 'reanahub/reana-env-root6'
+          imagetag: '6.18.04'
+          resources:
+            - compute_backend: htcondorcern
+  - name: fitdata
+    dependencies: [gendata]
+    scheduler:
+      scheduler_type: 'singlestep-stage'
+      parameters:
+        fitdata: {step: init, output: fitdata}
+        data: {step: gendata, output: data}
+        outfile: '{workdir}/plot.png'
+      step:
+        process:
+          process_type: 'interpolated-script-cmd'
+          script: root -b -q '{fitdata}("{data}","{outfile}")'
+        publisher:
+          publisher_type: 'frompar-pub'
+          outputmap:
+            plot: outfile
+        environment:
+          environment_type: 'docker-encapsulated'
+          image: 'reanahub/reana-env-root6'
+          imagetag: '6.18.04'
+          resources:
+            - compute_backend: htcondorcern

--- a/workflow/yadage/workflow-slurmcern.yaml
+++ b/workflow/yadage/workflow-slurmcern.yaml
@@ -1,0 +1,59 @@
+# Note that if you are working on the analysis development locally, i.e. outside
+# of the REANA platform, you can proceed as follows:
+#
+#   $ cd reana-demo-root6-roofit
+#   $ mkdir -p yadage-local-run/yadage-inputs
+#   $ cd yadage-local-run
+#   $ cp -a ../code yadage-inputs
+#   $ yadage-run . ../workflow/yadage/workflow.yaml \
+#        -p events=20000 \
+#        -p gendata=code/gendata.C \
+#        -p fitdata=code/fitdata.C \
+#        -d initdir=`pwd`/yadage-inputs
+#   $ firefox fitdata/plot.png
+
+stages:
+  - name: gendata
+    dependencies: [init]
+    scheduler:
+      scheduler_type: 'singlestep-stage'
+      parameters:
+        events: {step: init, output: events}
+        gendata: {step: init, output: gendata}
+        outfilename: '{workdir}/data.root'
+      step:
+        process:
+          process_type: 'interpolated-script-cmd'
+          script: root -b -q '{gendata}({events},"{outfilename}")'
+        publisher:
+          publisher_type: 'frompar-pub'
+          outputmap:
+            data: outfilename
+        environment:
+          environment_type: 'docker-encapsulated'
+          image: 'reanahub/reana-env-root6'
+          imagetag: '6.18.04'
+          resources:
+            - compute_backend: slurmcern
+  - name: fitdata
+    dependencies: [gendata]
+    scheduler:
+      scheduler_type: 'singlestep-stage'
+      parameters:
+        fitdata: {step: init, output: fitdata}
+        data: {step: gendata, output: data}
+        outfile: '{workdir}/plot.png'
+      step:
+        process:
+          process_type: 'interpolated-script-cmd'
+          script: root -b -q '{fitdata}("{data}","{outfile}")'
+        publisher:
+          publisher_type: 'frompar-pub'
+          outputmap:
+            plot: outfile
+        environment:
+          environment_type: 'docker-encapsulated'
+          image: 'reanahub/reana-env-root6'
+          imagetag: '6.18.04'
+          resources:
+            - compute_backend: slurmcern


### PR DESCRIPTION
- HTCondor Yadage example fully working. 

- Slurm Serial example fully working. 

- Slurm Yadage example is having an issue:

```
$ reana-client status -w yad-hpc
NAME      RUN_NUMBER   CREATED               STARTED               ENDED                 STATUS     PROGRESS
yad-hpc   3            2021-02-17T16:29:52   2021-02-17T16:29:53   2021-02-17T16:32:20   finished   2/2    
$ reana-client logs -w yad-hpc
==> Job logs
==> Step: gendata
...
==> Status: finished
==> Logs:
Auks API request failed : krb5 cred : unable to read credential cache
INFO:    Using cached SIF image
$ reana-client ls -w yad-hpc | grep reana_job
reana_job.945327.out                         0        2021-02-17T16:31:59
reana_job.945327.err                         102      2021-02-17T16:31:59
reana_job.945326.out                         0        2021-02-17T16:31:59
reana_job.945326.err                         102      2021-02-17T16:31:59
```

That is, the workflow is reported as finished, however there is no stdout, and stderr contains a message about  `krb5_cred` troubles. No `data.root` or `plot.png` are generated.

Since Serial Slurm example works well, this may be something particular to the r-w-e-yadage slurm integration?  (FWIW, the Serial Slurm example also generates those `krb5_cred` output messages is stderr.)