### PR TITLE
cwl: Slurm compute backend example

### DIFF
--- a/reana-cwl-slurmcern.yaml
+++ b/reana-cwl-slurmcern.yaml
@@ -1,0 +1,15 @@
+version: 0.6.0
+inputs:
+  files:
+    - code/gendata.C
+    - code/fitdata.C
+  directories:
+    - workflow/cwl
+  parameters:
+    input: workflow/cwl/input.yml
+workflow:
+  type: cwl
+  file: workflow/cwl/workflow-slurmcern.cwl
+outputs:
+  files:
+    - outputs/plot.png

--- a/workflow/cwl/workflow-slurmcern.cwl
+++ b/workflow/cwl/workflow-slurmcern.cwl
@@ -1,0 +1,50 @@
+#!/usr/bin/env cwl-runner
+
+# Note that if you are working on the analysis development locally, i.e. outside
+# of the REANA platform, you can proceed as follows:
+#
+#   $ cd reana-demo-root6-roofit
+#   $ mkdir cwl-local-run
+#   $ cd cwl-local-run
+#   $ cp -a ../code ../workflow/cwl/input.yml .
+#   $ cwltool --quiet --outdir="../results" ../workflow/cwl/workflow.cwl input.yml
+#   $ firefox ../results/plot.png
+
+
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  gendata_tool: File
+  fitdata_tool: File
+  events: int
+
+outputs:
+  plot:
+    type: File
+    outputSource:
+      fitdata/result
+
+steps:
+  gendata:
+    hints:
+      reana:
+        compute_backend: slurmcern
+    run: gendata.cwl
+    in:
+      gendata_tool: gendata_tool
+      events: events
+    out: [data]
+  fitdata:
+    hints:
+      reana:
+        compute_backend: slurmcern
+    run: fitdata.cwl
+    in:
+      fitdata: fitdata_tool
+      data: gendata/data
+    out: [result]
+
+$namespaces:
+  reana: https://www.reana.io
+


### PR DESCRIPTION
Works well:

```console
$ reana-client status -w roofit-cwl-hpc
NAME             RUN_NUMBER   CREATED               STARTED               ENDED                 STATUS     PROGRESS
roofit-cwl-hpc   1            2021-02-25T10:43:44   2021-02-25T10:43:45   2021-02-25T10:53:29   finished   2/2 

$ reana-client ls -w roofit-cwl-hpc | grep plot.png
outputs/plot.png                      15450    2021-02-25T10:53:24
cwl/docker_outdir/plot.png            15450    2021-02-25T10:53:24
```