### PR TITLE
snakemake: fix step inputs and params

### DIFF
--- a/workflow/snakemake/Snakefile
+++ b/workflow/snakemake/Snakefile
@@ -24,7 +24,7 @@ rule gendata:
     params:
         events=config["events"]
     container:
-        "reanahub/reana-env-root6:6.18.04"
+        "docker://reanahub/reana-env-root6:6.18.04"
     shell:
         "mkdir -p results && root -b -q '{input.gendata_tool}({params.events},\"{output}\")'"
 
@@ -35,6 +35,6 @@ rule fitdata:
     output:
         "results/plot.png"
     container:
-        "reanahub/reana-env-root6:6.18.04"
+        "docker://reanahub/reana-env-root6:6.18.04"
     shell:
         "root -b -q '{input.fitdata_tool}(\"{input.data}\",\"{output}\")'"

--- a/workflow/snakemake/Snakefile
+++ b/workflow/snakemake/Snakefile
@@ -15,7 +15,6 @@ rule all:
     input:
         "results/data.root",
         "results/plot.png"
-        
 
 rule gendata:
     input:
@@ -23,22 +22,19 @@ rule gendata:
     output:
         "results/data.root"
     params:
-        events=config["events"],
-        data=config["data"]
+        events=config["events"]
     container:
         "reanahub/reana-env-root6:6.18.04"
     shell:
-        "mkdir -p results && root -b -q '{input.gendata_tool}({params.events},\"{params.data}\")'"
+        "mkdir -p results && root -b -q '{input.gendata_tool}({params.events},\"{output}\")'"
 
 rule fitdata:
     input:
-        fitdata_tool=config["fitdata"]
+        fitdata_tool=config["fitdata"],
+        data="results/data.root"
     output:
         "results/plot.png"
     container:
         "reanahub/reana-env-root6:6.18.04"
-    params:
-        data=config["data"],
-        plot=config["plot"]
-    shell: 
-        "root -b -q '{input.fitdata_tool}(\"{params.data}\",\"{params.plot}\")'"
+    shell:
+        "root -b -q '{input.fitdata_tool}(\"{input.data}\",\"{output}\")'"

--- a/workflow/snakemake/inputs.yaml
+++ b/workflow/snakemake/inputs.yaml
@@ -1,5 +1,3 @@
 events: 20000
 fitdata: code/fitdata.C
 gendata: code/gendata.C
-data: results/data.root
-plot: results/plot.png


### PR DESCRIPTION
closes reanahub/reana-workflow-engine-snakemake#5

`fitdata` step didn't have `"results/data.root"` as input so rule order was not respected.