### PR TITLE
workflows: less strict memory limits

### DIFF
--- a/reana.yaml
+++ b/reana.yaml
@@ -13,12 +13,12 @@ workflow:
     steps:
       - name: gendata
         environment: 'reanahub/reana-env-root6:6.18.04'
-        kubernetes_memory_limit: '64Mi'
+        kubernetes_memory_limit: '256Mi'
         commands:
         - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
         environment: 'reanahub/reana-env-root6:6.18.04'
-        kubernetes_memory_limit: '64Mi'
+        kubernetes_memory_limit: '256Mi'
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:

--- a/workflow/cwl/workflow.cwl
+++ b/workflow/cwl/workflow.cwl
@@ -29,7 +29,7 @@ steps:
   gendata:
     hints:
       reana:
-        kubernetes_memory_limit: '64Mi'
+        kubernetes_memory_limit: '256Mi'
     run: gendata.cwl
     in:
       gendata_tool: gendata_tool
@@ -38,7 +38,7 @@ steps:
   fitdata:
     hints:
       reana:
-        kubernetes_memory_limit: '64Mi'
+        kubernetes_memory_limit: '256Mi'
     run: fitdata.cwl
     in:
       fitdata: fitdata_tool

--- a/workflow/snakemake/Snakefile
+++ b/workflow/snakemake/Snakefile
@@ -26,7 +26,7 @@ rule gendata:
     container:
         "docker://reanahub/reana-env-root6:6.18.04"
     resources:
-        kubernetes_memory_limit="64Mi"
+        kubernetes_memory_limit="256Mi"
     shell:
         "mkdir -p results && root -b -q '{input.gendata_tool}({params.events},\"{output}\")'"
 
@@ -39,6 +39,6 @@ rule fitdata:
     container:
         "docker://reanahub/reana-env-root6:6.18.04"
     resources:
-        kubernetes_memory_limit="64Mi"
+        kubernetes_memory_limit="256Mi"
     shell:
         "root -b -q '{input.fitdata_tool}(\"{input.data}\",\"{output}\")'"

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -34,7 +34,7 @@ stages:
           image: 'reanahub/reana-env-root6'
           imagetag: '6.18.04'
           resources:
-            - kubernetes_memory_limit: '64Mi'
+            - kubernetes_memory_limit: '256Mi'
   - name: fitdata
     dependencies: [gendata]
     scheduler:
@@ -56,4 +56,4 @@ stages:
           image: 'reanahub/reana-env-root6'
           imagetag: '6.18.04'
           resources:
-            - kubernetes_memory_limit: '64Mi'
+            - kubernetes_memory_limit: '256Mi'


### PR DESCRIPTION
Uses 256Mi instead of 64Mi which was not enough on some REANA
installations such as the the REANA production server at CERN.