### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2021 CERN.
+# Copyright (C) 2020, 2021, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -60,12 +60,12 @@ jobs:
         uses: reanahub/reana-github-actions/local-run@v1
         with:
           commands: |
-            docker run -i --rm -v `pwd`:/workdir reanahub/reana-env-root6 bash -c "
+            docker run -i --rm -v `pwd`:/workdir docker.io/reanahub/reana-env-root6 bash -c "
               cd /workdir &&
               mkdir -p ./results &&
               root -b -q './code/gendata.C(20000,\"./results/data.root\")'"
             ls -l `pwd`/results/data.root
-            docker run -i --rm -v `pwd`:/workdir reanahub/reana-env-root6 bash -c "
+            docker run -i --rm -v `pwd`:/workdir docker.io/reanahub/reana-env-root6 bash -c "
               cd /workdir &&
               root -b -q './code/fitdata.C(\"./results/data.root\",\"./results/plot.png\")'"
              ls -l `pwd`/results/plot.png

--- a/README.rst
+++ b/README.rst
@@ -184,11 +184,11 @@ workflow steps and expected outputs:
       specification:
         steps:
           - name: gendata
-            environment: 'reanahub/reana-env-root6:6.18.04'
+            environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
             commands:
             - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
           - name: fitdata
-            environment: 'reanahub/reana-env-root6:6.18.04'
+            environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
             commands:
             - root -b -q 'code/fitdata.C("${data}","${plot}")'
     outputs:

--- a/reana-htcondorcern.yaml
+++ b/reana-htcondorcern.yaml
@@ -12,13 +12,13 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'reanahub/reana-env-root6:6.18.04'
+        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
         compute_backend: htcondorcern
         htcondor_max_runtime: espresso
         commands:
         - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
-        environment: 'reanahub/reana-env-root6:6.18.04'
+        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
         compute_backend: htcondorcern
         htcondor_max_runtime: espresso
         commands:

--- a/reana-slurmcern.yaml
+++ b/reana-slurmcern.yaml
@@ -12,12 +12,12 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'reanahub/reana-env-root6:6.18.04'
+        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
         compute_backend: slurmcern
         commands:
         - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
-        environment: 'reanahub/reana-env-root6:6.18.04'
+        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
         compute_backend: slurmcern
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")'

--- a/reana.yaml
+++ b/reana.yaml
@@ -12,12 +12,12 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'reanahub/reana-env-root6:6.18.04'
+        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
         kubernetes_memory_limit: '256Mi'
         commands:
         - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
-        environment: 'reanahub/reana-env-root6:6.18.04'
+        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
         kubernetes_memory_limit: '256Mi'
         commands:
         - root -b -q 'code/fitdata.C("${data}","${plot}")'

--- a/workflow/cwl/fitdata.cwl
+++ b/workflow/cwl/fitdata.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 requirements:
   DockerRequirement:
     dockerPull:
-      reanahub/reana-env-root6:6.18.04
+      docker.io/reanahub/reana-env-root6:6.18.04
   InitialWorkDirRequirement:
     listing:
       - $(inputs.fitdata)

--- a/workflow/cwl/gendata.cwl
+++ b/workflow/cwl/gendata.cwl
@@ -4,7 +4,7 @@ class: CommandLineTool
 requirements:
   DockerRequirement:
     dockerPull:
-      reanahub/reana-env-root6:6.18.04
+      docker.io/reanahub/reana-env-root6:6.18.04
   InitialWorkDirRequirement:
     listing:
       - $(inputs.gendata_tool)

--- a/workflow/snakemake/Snakefile
+++ b/workflow/snakemake/Snakefile
@@ -24,7 +24,7 @@ rule gendata:
     params:
         events=config["events"]
     container:
-        "docker://reanahub/reana-env-root6:6.18.04"
+        "docker://docker.io/reanahub/reana-env-root6:6.18.04"
     resources:
         kubernetes_memory_limit="256Mi"
     shell:
@@ -37,7 +37,7 @@ rule fitdata:
     output:
         "results/plot.png"
     container:
-        "docker://reanahub/reana-env-root6:6.18.04"
+        "docker://docker.io/reanahub/reana-env-root6:6.18.04"
     resources:
         kubernetes_memory_limit="256Mi"
     shell:

--- a/workflow/snakemake/Snakefile-htcondorcern
+++ b/workflow/snakemake/Snakefile-htcondorcern
@@ -11,7 +11,7 @@ rule gendata:
     params:
         events=config["events"]
     container:
-        "docker://reanahub/reana-env-root6:6.18.04"
+        "docker://docker.io/reanahub/reana-env-root6:6.18.04"
     resources:
         compute_backend="htcondorcern",
         htcondor_max_runtime="espresso"
@@ -25,7 +25,7 @@ rule fitdata:
     output:
         "results/plot.png"
     container:
-        "docker://reanahub/reana-env-root6:6.18.04"
+        "docker://docker.io/reanahub/reana-env-root6:6.18.04"
     resources:
         compute_backend="htcondorcern",
         htcondor_max_runtime="espresso"

--- a/workflow/snakemake/Snakefile-slurmcern
+++ b/workflow/snakemake/Snakefile-slurmcern
@@ -11,7 +11,7 @@ rule gendata:
     params:
         events=config["events"]
     container:
-        "docker://reanahub/reana-env-root6:6.18.04"
+        "docker://docker.io/reanahub/reana-env-root6:6.18.04"
     resources:
         compute_backend="slurmcern"
     shell:
@@ -24,7 +24,7 @@ rule fitdata:
     output:
         "results/plot.png"
     container:
-        "docker://reanahub/reana-env-root6:6.18.04"
+        "docker://docker.io/reanahub/reana-env-root6:6.18.04"
     resources:
         compute_backend="slurmcern"
     shell:

--- a/workflow/yadage/workflow-htcondorcern.yaml
+++ b/workflow/yadage/workflow-htcondorcern.yaml
@@ -31,7 +31,7 @@ stages:
             data: outfilename
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'
           imagetag: '6.18.04'
           resources:
             - compute_backend: htcondorcern
@@ -54,7 +54,7 @@ stages:
             plot: outfile
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'
           imagetag: '6.18.04'
           resources:
             - compute_backend: htcondorcern

--- a/workflow/yadage/workflow-slurmcern.yaml
+++ b/workflow/yadage/workflow-slurmcern.yaml
@@ -31,7 +31,7 @@ stages:
             data: outfilename
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'
           imagetag: '6.18.04'
           resources:
             - compute_backend: slurmcern
@@ -53,7 +53,7 @@ stages:
             plot: outfile
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'
           imagetag: '6.18.04'
           resources:
             - compute_backend: slurmcern

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -31,7 +31,7 @@ stages:
             data: outfilename
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'
           imagetag: '6.18.04'
           resources:
             - kubernetes_memory_limit: '256Mi'
@@ -53,7 +53,7 @@ stages:
             plot: outfile
         environment:
           environment_type: 'docker-encapsulated'
-          image: 'reanahub/reana-env-root6'
+          image: 'docker.io/reanahub/reana-env-root6'
           imagetag: '6.18.04'
           resources:
             - kubernetes_memory_limit: '256Mi'


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.