### PR TITLE
test(serial): increase allowed workspace size

### DIFF
--- a/tests/serial/workspace-files.feature
+++ b/tests/serial/workspace-files.feature
@@ -24,4 +24,4 @@ Feature: Workspace files
     Scenario: The total workspace size remains within reasonable limits
         When the workflow is finished
         Then the workspace size should be more than 150KiB
-        And the workspace size should be less than 200KiB
+        And the workspace size should be less than 250KiB


### PR DESCRIPTION
Increases allowed workspace size for the Serial workflow slightly. This fixes a problem observed on a new system where the produced workflow size was 217088 bytes.