### PR TITLE
Adding unpacked containers for kubernetes backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 results/
+.idea
+.snakemake
+workflow/snakemake/.snakemake/log

--- a/reana-cwl-cvmfs.yaml
+++ b/reana-cwl-cvmfs.yaml
@@ -1,0 +1,15 @@
+version: 0.6.0
+inputs:
+  files:
+    - code/gendata.C
+    - code/fitdata.C
+  directories:
+    - workflow/cwl
+  parameters:
+    input: workflow/cwl/input.yml
+workflow:
+  type: cwl
+  file: workflow/cwl/workflow-cvmfs.cwl
+outputs:
+  files:
+    - outputs/plot.png

--- a/reana-serial-cvmfs.yaml
+++ b/reana-serial-cvmfs.yaml
@@ -1,0 +1,26 @@
+version: 0.6.0
+inputs:
+  files:
+    - code/gendata.C
+    - code/fitdata.C
+  parameters:
+    events: 20000
+    data: results/data.root
+    plot: results/plot.png
+workflow:
+  type: serial
+  specification:
+    steps:
+      - name: gendata
+        environment: '/cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04'
+        kubernetes_memory_limit: '256Mi'
+        commands:
+        - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
+      - name: fitdata
+        environment: '/cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04'
+        kubernetes_memory_limit: '256Mi'
+        commands:
+        - root -b -q 'code/fitdata.C("${data}","${plot}")'
+outputs:
+  files:
+    - results/plot.png

--- a/reana-snakemake-cvmfs.yaml
+++ b/reana-snakemake-cvmfs.yaml
@@ -1,0 +1,17 @@
+# Requires CVMFS (cvmfs.cern.ch) to be available on the Kubernetes cluster.
+# Container images are loaded from /cvmfs/unpacked.cern.ch via Apptainer.
+version: 0.8.0
+inputs:
+  files:
+    - code/gendata.C
+    - code/fitdata.C
+  directories:
+    - workflow/snakemake
+  parameters:
+    input: workflow/snakemake/inputs.yaml
+workflow:
+  type: snakemake
+  file: workflow/snakemake/Snakefile-cvmfs
+outputs:
+  files:
+    - results/plot.png

--- a/reana-yadage-cvmfs.yaml
+++ b/reana-yadage-cvmfs.yaml
@@ -1,0 +1,17 @@
+version: 0.6.0
+inputs:
+  files:
+    - code/gendata.C
+    - code/fitdata.C
+  directories:
+    - workflow/yadage
+  parameters:
+    events: 20000
+    gendata: code/gendata.C
+    fitdata: code/fitdata.C
+workflow:
+  type: yadage
+  file: workflow/yadage/workflow-cvmfs.yaml
+outputs:
+  files:
+    - fitdata/plot.png

--- a/workflow/cwl/fitdata-cvmfs.cwl
+++ b/workflow/cwl/fitdata-cvmfs.cwl
@@ -1,0 +1,31 @@
+cwlVersion: v1.0
+class: CommandLineTool
+
+requirements:
+  DockerRequirement:
+    dockerPull:
+      /cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04
+  InitialWorkDirRequirement:
+    listing:
+      - $(inputs.fitdata)
+      - $(inputs.data)
+
+inputs:
+  fitdata: File
+  data: File
+  outfile:
+    type: string
+    default: plot.png
+
+baseCommand: /bin/sh
+
+arguments:
+  - prefix: -c
+    valueFrom: |
+      root -b -q '$(inputs.fitdata.basename)("$(inputs.data.basename)","$(runtime.outdir)/$(inputs.outfile)")'
+
+outputs:
+  result:
+    type: File
+    outputBinding:
+      glob: $(inputs.outfile)

--- a/workflow/cwl/gendata-cvmfs.cwl
+++ b/workflow/cwl/gendata-cvmfs.cwl
@@ -1,0 +1,30 @@
+cwlVersion: v1.0
+class: CommandLineTool
+
+requirements:
+  DockerRequirement:
+    dockerPull:
+      /cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04
+  InitialWorkDirRequirement:
+    listing:
+      - $(inputs.gendata_tool)
+
+inputs:
+  gendata_tool: File
+  events: int
+  outfilename:
+    type: string
+    default: data.root
+
+baseCommand: /bin/sh
+
+arguments:
+  - prefix: -c
+    valueFrom: |
+      root -b -q '$(inputs.gendata_tool.basename)($(inputs.events),"$(runtime.outdir)/$(inputs.outfilename)")'
+
+outputs:
+  data:
+    type: File
+    outputBinding:
+      glob: $(inputs.outfilename)

--- a/workflow/cwl/workflow-cvmfs.cwl
+++ b/workflow/cwl/workflow-cvmfs.cwl
@@ -1,0 +1,38 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  gendata_tool: File
+  fitdata_tool: File
+  events: int
+
+outputs:
+  plot:
+    type: File
+    outputSource:
+      fitdata/result
+
+steps:
+  gendata:
+    hints:
+      reana:
+        kubernetes_memory_limit: '256Mi'
+    run: gendata-cvmfs.cwl
+    in:
+      gendata_tool: gendata_tool
+      events: events
+    out: [data]
+  fitdata:
+    hints:
+      reana:
+        kubernetes_memory_limit: '256Mi'
+    run: fitdata-cvmfs.cwl
+    in:
+      fitdata: fitdata_tool
+      data: gendata/data
+    out: [result]
+
+$namespaces:
+  reana: https://www.reana.io

--- a/workflow/snakemake/Snakefile-cvmfs
+++ b/workflow/snakemake/Snakefile-cvmfs
@@ -1,0 +1,34 @@
+# Requires CVMFS (cvmfs.cern.ch) to be available on the Kubernetes cluster.
+# Container images are loaded from /cvmfs/unpacked.cern.ch via Apptainer.
+
+rule all:
+    input:
+        "results/data.root",
+        "results/plot.png"
+
+rule gendata:
+    input:
+        gendata_tool=config["gendata"]
+    output:
+        "results/data.root"
+    params:
+        events=config["events"]
+    container:
+        "/cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04"
+    resources:
+        kubernetes_memory_limit="256Mi"
+    shell:
+        "mkdir -p results && root -b -q '{input.gendata_tool}({params.events},\"{output}\")'"
+
+rule fitdata:
+    input:
+        fitdata_tool=config["fitdata"],
+        data="results/data.root"
+    output:
+        "results/plot.png"
+    container:
+        "/cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04"
+    resources:
+        kubernetes_memory_limit="256Mi"
+    shell:
+        "root -b -q '{input.fitdata_tool}(\"{input.data}\",\"{output}\")'"

--- a/workflow/yadage/workflow-cvmfs.yaml
+++ b/workflow/yadage/workflow-cvmfs.yaml
@@ -1,0 +1,43 @@
+stages:
+  - name: gendata
+    dependencies: [init]
+    scheduler:
+      scheduler_type: 'singlestep-stage'
+      parameters:
+        events: {step: init, output: events}
+        gendata: {step: init, output: gendata}
+        outfilename: '{workdir}/data.root'
+      step:
+        process:
+          process_type: 'interpolated-script-cmd'
+          script: root -b -q '{gendata}({events},"{outfilename}")'
+        publisher:
+          publisher_type: 'frompar-pub'
+          outputmap:
+            data: outfilename
+        environment:
+          environment_type: 'docker-encapsulated'
+          image: '/cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04'
+          resources:
+            - kubernetes_memory_limit: '256Mi'
+  - name: fitdata
+    dependencies: [gendata]
+    scheduler:
+      scheduler_type: 'singlestep-stage'
+      parameters:
+        fitdata: {step: init, output: fitdata}
+        data: {step: gendata, output: data}
+        outfile: '{workdir}/plot.png'
+      step:
+        process:
+          process_type: 'interpolated-script-cmd'
+          script: root -b -q '{fitdata}("{data}","{outfile}")'
+        publisher:
+          publisher_type: 'frompar-pub'
+          outputmap:
+            plot: outfile
+        environment:
+          environment_type: 'docker-encapsulated'
+          image: '/cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04'
+          resources:
+            - kubernetes_memory_limit: '256Mi'


### PR DESCRIPTION
  - `reana-snakemake-cvmfs.yaml` — new workflow file pointing to `Snakefile-cvmfs`                        
  - `workflow/snakemake/Snakefile-cvmfs` — identical to the default Snakefile but container: uses   `/cvmfs/unpacked.cern.ch/registry.hub.docker.com/reanahub/reana-env-root6:6.18.04` instead of  docker://docker.io/reanahub/reana-env-root6:6.18.04

Depends-On: reanahub/reana-client#773
Closes https://github.com/reanahub/reana-job-controller/issues/483