### PR TITLE
ci(run-tests): refactor run-tests.sh and add linter checks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace=true
+
+[*.{css,html,js,json,scss,yaml,yml}]
+indent_size = 2
+
+[*.{py,sh}]
+indent_size = 4
+
+[*.go]
+indent_style = tab

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,25 @@
 name: ci
 
 on:
+
+lint-yamllint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,17 @@ lint-yamllint:
           pip install yamllint
           ./run-tests.sh --lint-yamllint
 
+format-shfmt:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check shell script code formatting
+        run: |
+          sudo apt-get install shfmt
+          ./run-tests.sh --format-shfmt
+
   push:
   pull_request:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
 # This file is part of REANA.
-# Copyright (C) 2020, 2021, 2023, 2024 CERN.
+# Copyright (C) 2020, 2021, 2023, 2024, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
-name: CI
+name: ci
 
 on:
   push:
@@ -32,12 +32,12 @@ jobs:
       - name: Check commit message compliance of the recently pushed commit
         if: github.event_name == 'push'
         run: |
-          ./run-tests.sh --check-commitlint HEAD~1 HEAD
+          ./run-tests.sh --lint-commitlint HEAD~1 HEAD
 
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
+          ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-24.04
@@ -48,7 +48,7 @@ jobs:
       - name: Runs shell script static analysis
         run: |
           sudo apt-get install shellcheck
-          ./run-tests.sh --check-shellcheck
+          ./run-tests.sh --lint-shellcheck
 
   cwl-validate:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   push:
   pull_request:
   schedule:
-    - cron: '0 7 * * 1'
+    - cron: "0 7 * * 1"
 
 jobs:
   cwl-local-run:
@@ -39,6 +39,20 @@ jobs:
         uses: reanahub/reana-github-actions/local-validate@v1
         with:
           reana_specs: reana-cwl*.yaml
+
+  format-prettier:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier code formatting
+        run: |
+          npm install prettier --global
+          ./run-tests.sh --format-prettier
 
   format-shfmt:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,26 +7,40 @@
 name: ci
 
 on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 7 * * 1'
 
-lint-yamllint:
+jobs:
+  cwl-local-run:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Run CWL locally
+        uses: reanahub/reana-github-actions/local-run@v1
         with:
-          fetch-depth: 0
+          commands: |
+            rm -rf cwl-local-run && mkdir -p cwl-local-run && cd cwl-local-run
+            pip install cwltool
+            cp -a ../code . && cp ../workflow/cwl/input.yml .
+            cwltool --quiet --outdir="./results" ../workflow/cwl/workflow.cwl input.yml
+            ls -l `pwd`/results/plot.png
+            cd .. && rm -rf cwl-local-run
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
+  cwl-validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate CWL spec
+        uses: reanahub/reana-github-actions/local-validate@v1
         with:
-          python-version: "3.12"
+          reana_specs: reana-cwl*.yaml
 
-      - name: Lint YAML files
-        run: |
-          pip install yamllint
-          ./run-tests.sh --lint-yamllint
-
-format-shfmt:
+  format-shfmt:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -37,12 +51,6 @@ format-shfmt:
           sudo apt-get install shfmt
           ./run-tests.sh --format-shfmt
 
-  push:
-  pull_request:
-  schedule:
-    - cron: '0 7 * * 1'
-
-jobs:
   lint-commitlint:
     runs-on: ubuntu-24.04
     steps:
@@ -69,6 +77,20 @@ jobs:
         run: |
           ./run-tests.sh --lint-commitlint ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
+  lint-markdownlint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+
+      - name: Lint Markdown files
+        run: |
+          npm install markdownlint-cli2 --global
+          ./run-tests.sh --lint-markdownlint
+
   lint-shellcheck:
     runs-on: ubuntu-24.04
     steps:
@@ -80,43 +102,21 @@ jobs:
           sudo apt-get install shellcheck
           ./run-tests.sh --lint-shellcheck
 
-  cwl-validate:
+  lint-yamllint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate CWL spec
-        uses: reanahub/reana-github-actions/local-validate@v1
+      - name: Setup Python
+        uses: actions/setup-python@v5
         with:
-          reana_specs: reana-cwl*.yaml
+          python-version: "3.12"
 
-  cwl-local-run:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run CWL locally
-        uses: reanahub/reana-github-actions/local-run@v1
-        with:
-          commands: |
-            rm -rf cwl-local-run && mkdir -p cwl-local-run && cd cwl-local-run
-            pip install cwltool
-            cp -a ../code . && cp ../workflow/cwl/input.yml .
-            cwltool --quiet --outdir="./results" ../workflow/cwl/workflow.cwl input.yml
-            ls -l `pwd`/results/plot.png
-            cd .. && rm -rf cwl-local-run
-
-  serial-validate:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Validate serial spec
-        uses: reanahub/reana-github-actions/local-validate@v1
-        with:
-          reana_specs: reana.yaml reana-htcondorcern.yaml reana-slurmcern.yaml
+      - name: Lint YAML files
+        run: |
+          pip install yamllint
+          ./run-tests.sh --lint-yamllint
 
   serial-local-run:
     runs-on: ubuntu-24.04
@@ -137,16 +137,16 @@ jobs:
               root -b -q './code/fitdata.C(\"./results/data.root\",\"./results/plot.png\")'"
              ls -l `pwd`/results/plot.png
 
-  snakemake-validate:
+  serial-validate:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Snakemake spec
+      - name: Validate serial spec
         uses: reanahub/reana-github-actions/local-validate@v1
         with:
-          reana_specs: reana-snakemake*.yaml
+          reana_specs: reana.yaml reana-htcondorcern.yaml reana-slurmcern.yaml
 
   snakemake-local-run:
     runs-on: ubuntu-24.04
@@ -174,16 +174,16 @@ jobs:
             ls -l `pwd`/results/plot.png
             cd .. && rm -rf snakemake-local-run
 
-  yadage-validate:
+  snakemake-validate:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Validate Yadage spec
+      - name: Validate Snakemake spec
         uses: reanahub/reana-github-actions/local-validate@v1
         with:
-          reana_specs: reana-yadage*.yaml
+          reana_specs: reana-snakemake*.yaml
 
   yadage-local-run:
     runs-on: ubuntu-24.04
@@ -200,3 +200,14 @@ jobs:
             yadage-run . ../workflow/yadage/workflow.yaml -p events=20000 -p gendata=code/gendata.C -p fitdata=code/fitdata.C -d initdir=`pwd`/yadage-inputs
             ls -l `pwd`/fitdata/plot.png
             cd .. && rm -rf yadage-local-run
+
+  yadage-validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Yadage spec
+        uses: reanahub/reana-github-actions/local-validate@v1
+        with:
+          reana_specs: reana-yadage*.yaml

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,7 @@
-# Allow long lines (to be fixed when prettier is added)
-MD013: false
+# Allow long lines in code blocks and tables
+MD013:
+  code_blocks: false
+  tables: false
 # Allow prompt dollar sign in console examples without showing output
 MD014: false
 # Allow flexible list spacing

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,6 @@
+# Allow long lines (to be fixed when prettier is added)
+MD013: false
+# Allow prompt dollar sign in console examples without showing output
+MD014: false
+# Allow flexible list spacing
+MD032: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,2 @@
+printWidth: 80
+proseWrap: always

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  comments:
+    min-spaces-from-content: 1
+  document-start: disable
+  line-length: disable
+  truthy: disable

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,6 +1,8 @@
 extends: default
 
 rules:
+  braces:
+    max-spaces-inside: 1
   comments:
     min-spaces-from-content: 1
   document-start: disable

--- a/README.md
+++ b/README.md
@@ -154,13 +154,13 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
+        environment: "docker.io/reanahub/reana-env-root6:6.18.04"
         commands:
-        - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
+          - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
-        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
+        environment: "docker.io/reanahub/reana-env-root6:6.18.04"
         commands:
-        - root -b -q 'code/fitdata.C("${data}","${plot}")'
+          - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:
   files:
     - results/plot.png

--- a/README.md
+++ b/README.md
@@ -7,59 +7,62 @@
 
 ## About
 
-This [REANA](http://www.reana.io/) reproducible analysis example emulates a typical
-particle physics analysis where the signal and background data is processed and fitted
-against a model. The example will use the [RooFit](https://root.cern.ch/roofit) package
-of the [ROOT](https://root.cern.ch/) framework.
+This [REANA](http://www.reana.io/) reproducible analysis example emulates a
+typical particle physics analysis where the signal and background data is
+processed and fitted against a model. The example will use the
+[RooFit](https://root.cern.ch/roofit) package of the
+[ROOT](https://root.cern.ch/) framework.
 
 ## Analysis structure
 
-Making a research data analysis reproducible basically means to provide "runnable
-recipes" addressing (1) where is the input data, (2) what software was used to analyse
-the data, (3) which computing environments were used to run the software and (4) which
-computational workflow steps were taken to run the analysis. This will permit to
-instantiate the analysis on the computational cloud and run the analysis to obtain (5)
-output results.
+Making a research data analysis reproducible basically means to provide
+"runnable recipes" addressing (1) where is the input data, (2) what software was
+used to analyse the data, (3) which computing environments were used to run the
+software and (4) which computational workflow steps were taken to run the
+analysis. This will permit to instantiate the analysis on the computational
+cloud and run the analysis to obtain (5) output results.
 
 ### 1. Input data
 
-In this example, the signal and background data will be generated; see below. Therefore
-there is no explicit input file to be taken care of.
+In this example, the signal and background data will be generated; see below.
+Therefore there is no explicit input file to be taken care of.
 
 ### 2. Analysis code
 
-The analysis will consist of two stages. In the first stage, signal and background are
-generated. In the second stage, a fit will be made for the signal and background.
+The analysis will consist of two stages. In the first stage, signal and
+background are generated. In the second stage, a fit will be made for the signal
+and background.
 
 For the first generation stage, [gendata.C](code/gendata.C) is a ROOT macro that
 generates signal and background data.
 
-For the second fitting stage, [fitdata.C](code/fitdata.C) is a ROOT macro that makes a
-fit for the signal and the background data.
+For the second fitting stage, [fitdata.C](code/fitdata.C) is a ROOT macro that
+makes a fit for the signal and the background data.
 
 The code was taken from the RooFit tutorial
-[rf502_wspacewrite.C](https://root.cern/doc/master/rf502__wspacewrite_8C.html) and was
-slightly modified.
+[rf502_wspacewrite.C](https://root.cern/doc/master/rf502__wspacewrite_8C.html)
+and was slightly modified.
 
 ### 3. Compute environment
 
-In order to be able to rerun the analysis even several years in the future, we need to
-"encapsulate the current compute environment", for example to freeze the ROOT version our
-analysis is using. We shall achieve this by preparing a [Docker](https://www.docker.com/)
-container image for our analysis steps.
+In order to be able to rerun the analysis even several years in the future, we
+need to "encapsulate the current compute environment", for example to freeze the
+ROOT version our analysis is using. We shall achieve this by preparing a
+[Docker](https://www.docker.com/) container image for our analysis steps.
 
 This analysis example is runs within the [ROOT6](https://root.cern.ch/) analysis
-framework. The computing environment can be therefore easily encapsulated by using the
-upstream [reana-env-root6](https://github.com/reanahub/reana-env-root6) base image. (See
+framework. The computing environment can be therefore easily encapsulated by
+using the upstream
+[reana-env-root6](https://github.com/reanahub/reana-env-root6) base image. (See
 there how it was created.)
 
-We shall use the ROOT version 6.18.04. Note that we can actually use this container image
-"as is", because our two macros `gendata.C` and `fitdata.C` can be "uploaded" and
-"mounted" into the running container at runtime. There is no need to compile any of the
-analysis source code beforehand. We can therefore use the ROOT 6.18.04 base image
-directly, without building a new container image specially dedicated to our analysis. The
-ROOT 6.18.04 base image fully specifies the complete analysis environment that we need
-for our analysis.
+We shall use the ROOT version 6.18.04. Note that we can actually use this
+container image "as is", because our two macros `gendata.C` and `fitdata.C` can
+be "uploaded" and "mounted" into the running container at runtime. There is no
+need to compile any of the analysis source code beforehand. We can therefore use
+the ROOT 6.18.04 base image directly, without building a new container image
+specially dedicated to our analysis. The ROOT 6.18.04 base image fully specifies
+the complete analysis environment that we need for our analysis.
 
 ### 4. Analysis workflow
 
@@ -98,8 +101,8 @@ $ ls -l plot.png
 ```
 
 Note that you can also use [CWL](http://www.commonwl.org/v1.0/),
-[Yadage](https://github.com/diana-hep/yadage) or [Snakemake](https://snakemake.github.io)
-workflow specifications:
+[Yadage](https://github.com/diana-hep/yadage) or
+[Snakemake](https://snakemake.github.io) workflow specifications:
 
 - [workflow definition using CWL](workflow/cwl/workflow.cwl)
 - [workflow definition using Yadage](workflow/yadage/workflow.yaml)
@@ -107,19 +110,19 @@ workflow specifications:
 
 ### 5. Output results
 
-The example produces a plot where the signal and background data is fitted against the
-model:
+The example produces a plot where the signal and background data is fitted
+against the model:
 
-![](https://raw.githubusercontent.com/reanahub/reana-demo-root6-roofit/master/docs/plot.png)
+![image](https://raw.githubusercontent.com/reanahub/reana-demo-root6-roofit/master/docs/plot.png)
 
 ## Running the example on REANA cloud
 
 There are two ways to execute this analysis example on REANA.
 
-If you would like to simply launch this analysis example on the REANA instance at CERN
-and inspect its results using the web interface, please click on one of the following
-badges, depending on which workflow system (CWL, Serial, Snakemake, Yadage) you would
-like to use:
+If you would like to simply launch this analysis example on the REANA instance
+at CERN and inspect its results using the web interface, please click on one of
+the following badges, depending on which workflow system (CWL, Serial,
+Snakemake, Yadage) you would like to use:
 
 [![Launch with CWL on REANA@CERN badge](https://www.reana.io/static/img/badges/launch-with-cwl-on-reana-at-cern.svg)](https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-root6-roofit&specification=reana-cwl.yaml&name=reana-demo-root6-roofit-cwl)
 
@@ -129,12 +132,12 @@ like to use:
 
 [![Launch with Yadage on REANA@CERN badge](https://www.reana.io/static/img/badges/launch-with-yadage-on-reana-at-cern.svg)](https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-root6-roofit&specification=reana-yadage.yaml&name=reana-demo-root6-roofit-yadage)
 
-If you would like a step-by-step guide on how to use the REANA command-line client to
-launch this analysis example, please read on.
+If you would like a step-by-step guide on how to use the REANA command-line
+client to launch this analysis example, please read on.
 
-We start by creating a [reana.yaml](reana.yaml) file describing the above analysis
-structure with its inputs, code, runtime environment, computational workflow steps and
-expected outputs:
+We start by creating a [reana.yaml](reana.yaml) file describing the above
+analysis structure with its inputs, code, runtime environment, computational
+workflow steps and expected outputs:
 
 ```yaml
 version: 0.6.0
@@ -163,14 +166,15 @@ outputs:
     - results/plot.png
 ```
 
-In this example we are using a simple Serial workflow engine to represent our sequential
-computational workflow steps. Note that we can also use the CWL workflow specification
-(see [reana-cwl.yaml](reana-cwl.yaml)), the Yadage workflow specification (see
-[reana-yadage.yaml](reana-yadage.yaml)) or the Snakemake workflow specification (see
+In this example we are using a simple Serial workflow engine to represent our
+sequential computational workflow steps. Note that we can also use the CWL
+workflow specification (see [reana-cwl.yaml](reana-cwl.yaml)), the Yadage
+workflow specification (see [reana-yadage.yaml](reana-yadage.yaml)) or the
+Snakemake workflow specification (see
 [reana-snakemake.yaml](reana-snakemake.yaml)).
 
-We can now install the REANA command-line client, run the analysis and download the
-resulting plots:
+We can now install the REANA command-line client, run the analysis and download
+the resulting plots:
 
 ```console
 $ # create new virtual environment
@@ -196,5 +200,6 @@ $ # download output results
 $ reana-client download
 ```
 
-Please see the [REANA-Client](https://reana-client.readthedocs.io/) documentation for
-more detailed explanation of typical `reana-client` usage scenarios.
+Please see the [REANA-Client](https://reana-client.readthedocs.io/)
+documentation for more detailed explanation of typical `reana-client` usage
+scenarios.

--- a/reana-htcondorcern.yaml
+++ b/reana-htcondorcern.yaml
@@ -12,17 +12,17 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
+        environment: "docker.io/reanahub/reana-env-root6:6.18.04"
         compute_backend: htcondorcern
         htcondor_max_runtime: espresso
         commands:
-        - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
+          - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
-        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
+        environment: "docker.io/reanahub/reana-env-root6:6.18.04"
         compute_backend: htcondorcern
         htcondor_max_runtime: espresso
         commands:
-        - root -b -q 'code/fitdata.C("${data}","${plot}")'
+          - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:
   files:
     - results/plot.png

--- a/reana-slurmcern.yaml
+++ b/reana-slurmcern.yaml
@@ -12,15 +12,15 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
+        environment: "docker.io/reanahub/reana-env-root6:6.18.04"
         compute_backend: slurmcern
         commands:
-        - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
+          - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
-        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
+        environment: "docker.io/reanahub/reana-env-root6:6.18.04"
         compute_backend: slurmcern
         commands:
-        - root -b -q 'code/fitdata.C("${data}","${plot}")'
+          - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:
   files:
     - results/plot.png

--- a/reana.yaml
+++ b/reana.yaml
@@ -12,15 +12,15 @@ workflow:
   specification:
     steps:
       - name: gendata
-        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
-        kubernetes_memory_limit: '256Mi'
+        environment: "docker.io/reanahub/reana-env-root6:6.18.04"
+        kubernetes_memory_limit: "256Mi"
         commands:
-        - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
+          - mkdir -p results && root -b -q 'code/gendata.C(${events},"${data}")'
       - name: fitdata
-        environment: 'docker.io/reanahub/reana-env-root6:6.18.04'
-        kubernetes_memory_limit: '256Mi'
+        environment: "docker.io/reanahub/reana-env-root6:6.18.04"
+        kubernetes_memory_limit: "256Mi"
         commands:
-        - root -b -q 'code/fitdata.C("${data}","${plot}")'
+          - root -b -q 'code/fitdata.C("${data}","${plot}")'
 outputs:
   files:
     - results/plot.png

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # This file is part of REANA.
-# Copyright (C) 2024 CERN.
+# Copyright (C) 2024, 2025, 2026 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -9,11 +9,15 @@
 set -o errexit
 set -o nounset
 
-check_commitlint () {
+lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
     pr=${4:-[0-9]+}
-    npx commitlint --from="$from" --to="$to"
+    if command -v commitlint >/dev/null 2>&1; then
+        commitlint --from="$from" --to="$to"
+    else
+        npx commitlint --from="$from" --to="$to"
+    fi
     found=0
     while IFS= read -r line; do
         commit_hash=$(echo "$line" | cut -d ' ' -f 1)
@@ -43,23 +47,34 @@ check_commitlint () {
     fi
 }
 
-check_shellcheck () {
+lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
-check_all () {
-    check_commitlint
-    check_shellcheck
+all() {
+    lint_commitlint
+    lint_shellcheck
+}
+
+help() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  --all              Perform all checks [default]"
+    echo "  --help             Display this help message"
+    echo "  --lint-commitlint  Check linting of commit messages"
+    echo "  --lint-shellcheck  Check linting of shell scripts"
 }
 
 if [ $# -eq 0 ]; then
-    check_all
+    all
     exit 0
 fi
 
 arg="$1"
 case $arg in
-    --check-commitlint) check_commitlint "$@";;
-    --check-shellcheck) check_shellcheck;;
-    *) echo "[ERROR] Invalid argument '$arg'. Exiting." && exit 1;;
+--all) all ;;
+--help) help ;;
+--lint-commitlint) lint_commitlint "$@" ;;
+--lint-shellcheck) lint_shellcheck ;;
+*) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_shfmt() {
+    shfmt -d .
+}
+
 lint_commitlint() {
     from=${2:-master}
     to=${3:-HEAD}
@@ -35,7 +39,7 @@ lint_commitlint() {
         # (iii) check absence of merge commits in feature branches
         if [ "$commit_number_of_parents" -gt 1 ]; then
             if echo "$commit_title" | grep -qE "^chore\(.*\): merge "; then
-                break  # skip checking maint-to-master merge commits
+                break # skip checking maint-to-master merge commits
             else
                 echo "✖   Merge commits are not allowed in feature branches: $commit_title"
                 found=1
@@ -56,6 +60,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_shfmt
     lint_commitlint
     lint_shellcheck
     lint_yamllint
@@ -65,6 +70,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all              Perform all checks [default]"
+    echo "  --format-shfmt     Check formatting of shell scripts"
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
@@ -80,6 +86,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,6 +9,10 @@
 set -o errexit
 set -o nounset
 
+format_prettier() {
+    prettier -c .
+}
+
 format_shfmt() {
     shfmt -d .
 }
@@ -64,6 +68,7 @@ lint_yamllint() {
 }
 
 all() {
+    format_prettier
     format_shfmt
     lint_commitlint
     lint_markdownlint
@@ -75,6 +80,7 @@ help() {
     echo "Usage: $0 [options]"
     echo "Options:"
     echo "  --all                Perform all checks [default]"
+    echo "  --format-prettier    Check formatting of Markdown etc files"
     echo "  --format-shfmt       Check formatting of shell scripts"
     echo "  --help               Display this help message"
     echo "  --lint-commitlint    Check linting of commit messages"
@@ -92,6 +98,7 @@ arg="$1"
 case $arg in
 --all) all ;;
 --help) help ;;
+--format-prettier) format_prettier ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-markdownlint) lint_markdownlint ;;

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,9 +51,14 @@ lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
 
+lint_yamllint() {
+    yamllint .
+}
+
 all() {
     lint_commitlint
     lint_shellcheck
+    lint_yamllint
 }
 
 help() {
@@ -63,6 +68,7 @@ help() {
     echo "  --help             Display this help message"
     echo "  --lint-commitlint  Check linting of commit messages"
     echo "  --lint-shellcheck  Check linting of shell scripts"
+    echo "  --lint-yamllint    Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -76,5 +82,6 @@ case $arg in
 --help) help ;;
 --lint-commitlint) lint_commitlint "$@" ;;
 --lint-shellcheck) lint_shellcheck ;;
+--lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;
 esac

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,6 +51,10 @@ lint_commitlint() {
     fi
 }
 
+lint_markdownlint() {
+    markdownlint-cli2 "**/*.md"
+}
+
 lint_shellcheck() {
     find . -name "*.sh" -exec shellcheck {} \+
 }
@@ -62,6 +66,7 @@ lint_yamllint() {
 all() {
     format_shfmt
     lint_commitlint
+    lint_markdownlint
     lint_shellcheck
     lint_yamllint
 }
@@ -69,12 +74,13 @@ all() {
 help() {
     echo "Usage: $0 [options]"
     echo "Options:"
-    echo "  --all              Perform all checks [default]"
-    echo "  --format-shfmt     Check formatting of shell scripts"
-    echo "  --help             Display this help message"
-    echo "  --lint-commitlint  Check linting of commit messages"
-    echo "  --lint-shellcheck  Check linting of shell scripts"
-    echo "  --lint-yamllint    Check linting of YAML files"
+    echo "  --all                Perform all checks [default]"
+    echo "  --format-shfmt       Check formatting of shell scripts"
+    echo "  --help               Display this help message"
+    echo "  --lint-commitlint    Check linting of commit messages"
+    echo "  --lint-markdownlint  Check linting of Markdown files"
+    echo "  --lint-shellcheck    Check linting of shell scripts"
+    echo "  --lint-yamllint      Check linting of YAML files"
 }
 
 if [ $# -eq 0 ]; then
@@ -88,6 +94,7 @@ case $arg in
 --help) help ;;
 --format-shfmt) format_shfmt ;;
 --lint-commitlint) lint_commitlint "$@" ;;
+--lint-markdownlint) lint_markdownlint ;;
 --lint-shellcheck) lint_shellcheck ;;
 --lint-yamllint) lint_yamllint ;;
 *) echo "[ERROR] Invalid argument '$arg'. Exiting." && help && exit 1 ;;

--- a/workflow/yadage/workflow-htcondorcern.yaml
+++ b/workflow/yadage/workflow-htcondorcern.yaml
@@ -16,46 +16,46 @@ stages:
   - name: gendata
     dependencies: [init]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        events: {step: init, output: events}
-        gendata: {step: init, output: gendata}
-        outfilename: '{workdir}/data.root'
+        events: { step: init, output: events }
+        gendata: { step: init, output: gendata }
+        outfilename: "{workdir}/data.root"
       step:
         process:
-          process_type: 'interpolated-script-cmd'
+          process_type: "interpolated-script-cmd"
           script: root -b -q '{gendata}({events},"{outfilename}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             data: outfilename
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
-          imagetag: '6.18.04'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"
+          imagetag: "6.18.04"
           resources:
             - compute_backend: htcondorcern
             - htcondor_max_runtime: espresso
   - name: fitdata
     dependencies: [gendata]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        fitdata: {step: init, output: fitdata}
-        data: {step: gendata, output: data}
-        outfile: '{workdir}/plot.png'
+        fitdata: { step: init, output: fitdata }
+        data: { step: gendata, output: data }
+        outfile: "{workdir}/plot.png"
       step:
         process:
-          process_type: 'interpolated-script-cmd'
+          process_type: "interpolated-script-cmd"
           script: root -b -q '{fitdata}("{data}","{outfile}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             plot: outfile
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
-          imagetag: '6.18.04'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"
+          imagetag: "6.18.04"
           resources:
             - compute_backend: htcondorcern
             - htcondor_max_runtime: espresso

--- a/workflow/yadage/workflow-slurmcern.yaml
+++ b/workflow/yadage/workflow-slurmcern.yaml
@@ -16,44 +16,44 @@ stages:
   - name: gendata
     dependencies: [init]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        events: {step: init, output: events}
-        gendata: {step: init, output: gendata}
-        outfilename: '{workdir}/data.root'
+        events: { step: init, output: events }
+        gendata: { step: init, output: gendata }
+        outfilename: "{workdir}/data.root"
       step:
         process:
-          process_type: 'interpolated-script-cmd'
+          process_type: "interpolated-script-cmd"
           script: root -b -q '{gendata}({events},"{outfilename}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             data: outfilename
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
-          imagetag: '6.18.04'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"
+          imagetag: "6.18.04"
           resources:
             - compute_backend: slurmcern
   - name: fitdata
     dependencies: [gendata]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        fitdata: {step: init, output: fitdata}
-        data: {step: gendata, output: data}
-        outfile: '{workdir}/plot.png'
+        fitdata: { step: init, output: fitdata }
+        data: { step: gendata, output: data }
+        outfile: "{workdir}/plot.png"
       step:
         process:
-          process_type: 'interpolated-script-cmd'
+          process_type: "interpolated-script-cmd"
           script: root -b -q '{fitdata}("{data}","{outfile}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             plot: outfile
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
-          imagetag: '6.18.04'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"
+          imagetag: "6.18.04"
           resources:
             - compute_backend: slurmcern

--- a/workflow/yadage/workflow.yaml
+++ b/workflow/yadage/workflow.yaml
@@ -16,44 +16,44 @@ stages:
   - name: gendata
     dependencies: [init]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        events: {step: init, output: events}
-        gendata: {step: init, output: gendata}
-        outfilename: '{workdir}/data.root'
+        events: { step: init, output: events }
+        gendata: { step: init, output: gendata }
+        outfilename: "{workdir}/data.root"
       step:
         process:
-          process_type: 'interpolated-script-cmd'
+          process_type: "interpolated-script-cmd"
           script: root -b -q '{gendata}({events},"{outfilename}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             data: outfilename
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
-          imagetag: '6.18.04'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"
+          imagetag: "6.18.04"
           resources:
-            - kubernetes_memory_limit: '256Mi'
+            - kubernetes_memory_limit: "256Mi"
   - name: fitdata
     dependencies: [gendata]
     scheduler:
-      scheduler_type: 'singlestep-stage'
+      scheduler_type: "singlestep-stage"
       parameters:
-        fitdata: {step: init, output: fitdata}
-        data: {step: gendata, output: data}
-        outfile: '{workdir}/plot.png'
+        fitdata: { step: init, output: fitdata }
+        data: { step: gendata, output: data }
+        outfile: "{workdir}/plot.png"
       step:
         process:
-          process_type: 'interpolated-script-cmd'
+          process_type: "interpolated-script-cmd"
           script: root -b -q '{fitdata}("{data}","{outfile}")'
         publisher:
-          publisher_type: 'frompar-pub'
+          publisher_type: "frompar-pub"
           outputmap:
             plot: outfile
         environment:
-          environment_type: 'docker-encapsulated'
-          image: 'docker.io/reanahub/reana-env-root6'
-          imagetag: '6.18.04'
+          environment_type: "docker-encapsulated"
+          image: "docker.io/reanahub/reana-env-root6"
+          imagetag: "6.18.04"
           resources:
-            - kubernetes_memory_limit: '256Mi'
+            - kubernetes_memory_limit: "256Mi"


### PR DESCRIPTION
- Refactors `run-tests.sh` to add usage help, standardise function naming, and improve option handling.
- Adds new linter and formatter checks where applicable (yamllint, shfmt, markdownlint, prettier, jsonlint).
- Updates `.github/workflows/ci.yml` with corresponding CI jobs.